### PR TITLE
using <images> eliminates maki

### DIFF
--- a/xml/main.xml
+++ b/xml/main.xml
@@ -113,12 +113,12 @@
 
 <groupdef id="sliders">
 
-	<AnimatedLayer id="volume" w="68" h="15" image="volume" start="0" end="27" frameheight="15" ghost="1"/>
-	<Slider id="volumewa2" action="volume" orientation="horizontal" x="0" y="-1" w="65" h="15" thumb="volbtn" downThumb="volbtnd"/>
-	<script file="scripts/volume.maki"/>
-	<AnimatedLayer id="balancewa2" x="70" w="38" h="15" image="balance" start="0" end="27" frameheight="15" ghost="1"/>
+	<images id="volume.anim" source="volume" w="68" h="14" images="volume" imagesspacing="15"/>
+	<Slider id="volume" action="volume" orientation="horizontal" x="0" y="-1" w="65" h="15" thumb="volbtn" downThumb="volbtnd"/>
+	<!-- <script file="scripts/volume.maki"/> -->
+	<images id="balance.anim" source="balance" x="70" w="38" h="15" images="balance" imagesspacing="15" ghost="1"/>
 	<Slider id="balance" action="PAN" orientation="horizontal" x="70" y="-1" w="38" h="15" thumb="panbtn" downThumb="panbtnd"/>
-	<script file="scripts/balance.maki"/>
+	<!-- <script file="scripts/balance.maki"/> -->
 </groupdef>
 
 <groupdef id="waclassicvis">


### PR DESCRIPTION
based on winamp official wiki, there is an <images>  (xml tag) that can be used to make slider background colours animates automatically by a slider changes.

http://wiki.winamp.com/wiki/XML_GUI_Objects#.3Cimages.2F.3E